### PR TITLE
Fix/update `uppercase` custom function example per latest `messageformat@next`

### DIFF
--- a/docs/integration/js.md
+++ b/docs/integration/js.md
@@ -182,13 +182,15 @@ providing definitions for custom functions. To start with, let's write code for
 a simple custom function:
 
 ```js
-/**
- * @params {string[]} locales
- * @params {Record<string, unknown>} options
- * @params {string} value
- */
-function uppercase(locales, options, value) {
-  return { toString: () => value.toUpperCase() };
+import { DefaultFunctions, asString } from "messageformat@next/functions";
+
+/** @type {typeof DefaultFunctions.string} */
+function uppercase(context, options, input) {
+  return DefaultFunctions.string(
+    context,
+    options,
+    asString(input).toLocaleUpperCase(context.locales),
+  );
 }
 ```
 
@@ -196,6 +198,8 @@ Now that this function is defined, we can pass it to the `MessageFormat`
 constructor as part of the third argument:
 
 ```js
+import { MessageFormat } from "messageformat@next";
+
 const mf = new MessageFormat(
   ["en"],
   "{messageformat :uppercase}",


### PR DESCRIPTION
* Param types fixed (first arg is `context: MessageFunctionContext`, not `locales: string[]`)
* Return type fixed — only including `toString` doesn't work with `format` or `formatToParts`
* Use `toLocaleUpperCase` with the locales available in the context, rather than locale-less `toUpperCase`

It seems like building on top of the built-in `DefaultFunctions.string` is the simplest way to implement a custom `string -> string` function that correctly implements the contract expected by `format` and `formatToParts`. The returned object for input `"{messageformat :uppercase}"` looks roughly like this:

```ts
{
  type: "string",
  source: "|messageformat|",
  dir: "auto",
  selectKey: (keys) => (keys.has(selStr) ? selStr : null),
  toParts: () => [{ type: "string", source: "|messageformat|", locale: "en", value: "MESSAGEFORMAT" }],
  toString: () => "MESSAGEFORMAT",
  valueOf: () => "MESSAGEFORMAT"
}
```