### PR TITLE
Minor grammar fix

### DIFF
--- a/index.page.tsx
+++ b/index.page.tsx
@@ -188,7 +188,7 @@ export function Examples() {
           </p>
           <p>
             MessageFormat 2 doesn't assign meaning to markup, giving full
-            control over it's meaning and rendering to the developer.
+            control over its meaning and rendering to the developer.
           </p>
         </ExampleProse>
         <MarkupCode />


### PR DESCRIPTION
Change possessive "it's meaning and rendering" -> "its meaning and rendering" on the front page.